### PR TITLE
Fix auth URL and handle server down

### DIFF
--- a/cypress/integration/visitorCanRegister.feature.js
+++ b/cypress/integration/visitorCanRegister.feature.js
@@ -16,12 +16,12 @@ describe("Visitor can register", () => {
   it("successfully with valid credentials", () => {
     cy.route({
       method: "POST",
-      url: "http://localhost:3000/api/v1/auth?confirm_success_url=http://localhost:3000",
+      url: "http://localhost:3000/api/v1/auth",
       response: "fixture:signup.json"
     });
     cy.route({
       method: "GET",
-      url: "http://localhost:3000/api/v1/auth?confirm_success_url=http://localhost:3000",
+      url: "http://localhost:3000/api/v1/auth",
       response: "fixture:signup.json"
     });
 

--- a/src/components/Signup.jsx
+++ b/src/components/Signup.jsx
@@ -10,7 +10,7 @@ const Signup = props => {
       .signUp({
         email: event.target.email.value, 
         password: event.target.password.value
-      }, "http://localhost:3000")
+      })
       .then(userDatas => {
         props.changeAuth(true);
         props.changeAuthMessage(`Welcome! ${userDatas.data.data.email}`);

--- a/src/modules/article.js
+++ b/src/modules/article.js
@@ -5,7 +5,11 @@ const getCurrentArticle = async id => {
     const response = await axios.get(`/articles/${id}`);
     return response.data.article;
   } catch (error) {
-    return error.response.data;
+    if (!error.status) {
+      return { error: error.message }
+    } else {
+      return error.response.data;
+    }
   }
 };
 

--- a/src/modules/article.js
+++ b/src/modules/article.js
@@ -5,7 +5,7 @@ const getCurrentArticle = async id => {
     const response = await axios.get(`/articles/${id}`);
     return response.data.article;
   } catch (error) {
-    if (!error.status) {
+    if (error === 'Network Error') {
       return { error: error.message }
     } else {
       return error.response.data;

--- a/src/modules/auth.js
+++ b/src/modules/auth.js
@@ -1,8 +1,7 @@
 import JtockAuth from "j-tockauth";
 
 const auth = new JtockAuth ({
-  host: "http://localhost:3000",
-  prefixUrl: "/api/v1",
+  host: process.env.REACT_APP_BASEURL,
   debug: false
 });
 


### PR DESCRIPTION
[PT - Fix auth module URL and handle server down](https://www.pivotaltracker.com/story/show/170865921)

Handles Network Error when client can not connect to backend
Replaces hard coded localhost url in auth module with env variable
Removes redirect to localhost on signup, no redirect is needed.