### PR TITLE
(Bug) Subscriber gets truncated article

### DIFF
--- a/src/modules/article.js
+++ b/src/modules/article.js
@@ -1,9 +1,12 @@
 import axios from "axios";
 
 const getCurrentArticle = async (id, language) => {
+  let headers = JSON.parse(localStorage.getItem("J-tockAuth-Storage"));
   try {
-    const response = await axios.get(`/articles/${id}`, {
-      params: { locale: language }
+    const response = await axios({
+      url: `/articles/${id}`,
+      params: { locale: language },
+      headers: headers
     });
     return response.data.article;
   } catch (error) {


### PR DESCRIPTION
- Fixes bug where subscriber did not get full article.

- Problem was that no headers were sent in with get request in getCurrentArticle

Note to self: 
- Hard to test with cypress when everything is stubbed out.
- Write articles in fixture file to be more realistic.