### PR TITLE
Visitor can change page

### DIFF
--- a/cypress/fixtures/side_articles_shown.json
+++ b/cypress/fixtures/side_articles_shown.json
@@ -23,18 +23,6 @@
       "title": "Test4",
       "body": "TestBody4",
       "category": "4"
-    },
-    {
-      "id": 5,
-      "title": "Test5",
-      "body": "TestBody5",
-      "category": "4"
-    },
-    {
-      "id": 6,
-      "title": "Test6",
-      "body": "TestBody6",
-      "category": "4"
     }
   ],
   "meta": {

--- a/cypress/fixtures/side_articles_shown.json
+++ b/cypress/fixtures/side_articles_shown.json
@@ -23,6 +23,18 @@
       "title": "Test4",
       "body": "TestBody4",
       "category": "4"
+    },
+    {
+      "id": 5,
+      "title": "Test5",
+      "body": "TestBody5",
+      "category": "4"
+    },
+    {
+      "id": 6,
+      "title": "Test6",
+      "body": "TestBody6",
+      "category": "4"
     }
   ],
   "meta": {
@@ -30,6 +42,6 @@
     "next_page": 2,
     "prev_page": null,
     "total_pages": 2,
-    "total_count": 5
+    "total_count": 6
   }
 }

--- a/cypress/fixtures/side_articles_shown_page2.json
+++ b/cypress/fixtures/side_articles_shown_page2.json
@@ -1,0 +1,23 @@
+{
+  "articles": [
+    {
+      "id": 5,
+      "title": "Test5",
+      "body": "TestBody5",
+      "category": "4"
+    },
+    {
+      "id": 6,
+      "title": "Test6",
+      "body": "TestBody6",
+      "category": "4"
+    }
+  ],
+  "meta": {
+    "current_page": 2,
+    "next_page": null,
+    "prev_page": 1,
+    "total_pages": 2,
+    "total_count": 6
+  }
+}

--- a/cypress/integration/categorization.feature.js
+++ b/cypress/integration/categorization.feature.js
@@ -18,7 +18,7 @@ describe("Visitor succesfully", () => {
   it("shown side articles categorized", () => {
     cy.route({
       method: "GET",
-      url: "http://localhost:3000/api/v1/articles?category=culture**",
+      url: "http://localhost:3000/api/v1/articles?**category=culture**",
       response: "fixture:categorized_response.json",
       status: 200
     });
@@ -40,7 +40,7 @@ describe("Visitor succesfully", () => {
     });
     cy.route({
       method: "GET",
-      url: "http://localhost:3000/api/v1/articles?category=culture**",
+      url: "http://localhost:3000/api/v1/articles?**category=culture",
       response: "fixture:categorized_response.json",
       status: 200
     });
@@ -80,7 +80,7 @@ describe("Visitor succesfully", () => {
   it("gets error message is no articles in that cat exist", () => {
     cy.route({
       method: "GET",
-      url: "http://localhost:3000/api/v1/articles**",
+      url: "http://localhost:3000/api/v1/articles?**",
       response: "fixture:side_articles_empty.json",
       status: 200
     });
@@ -91,10 +91,9 @@ describe("Visitor succesfully", () => {
       status: 200
     });
     cy.visit("/");
-    cy.get("#return")
-      .contains("The Herald")
+    cy.get("#culture")
       .click();
 
-    cy.get("#message").should("contain", "No articles in that category yet");
+    cy.get("#error-message").should("contain", "No articles in that category yet");
   });
 });

--- a/cypress/integration/visitorCanChangePage.feature.js
+++ b/cypress/integration/visitorCanChangePage.feature.js
@@ -1,0 +1,13 @@
+describe("Visitor can change page and get more articles", () => {
+  it("successfully", () => {
+    cy.route({
+      method: "GET",
+      url: "http://localhost:3000/api/v1/articles**",
+      response: "fixture:side_articles_shown.json"
+    });
+    cy.visit("/");
+    cy.get("#next-button").click()
+    cy.get("#side-articles-1")
+      .should("contain", "Test6");
+  });
+});

--- a/cypress/integration/visitorCanChangePage.feature.js
+++ b/cypress/integration/visitorCanChangePage.feature.js
@@ -29,6 +29,8 @@ describe("Visitor can change page and another set of articles", () => {
     });
     cy.visit("/");
     cy.get("#next-button").click()
+    cy.get("#side-article-6")
+      .should("contain", "Test6");
     cy.get("#prev-button").click()
     cy.get("#side-article-3")
       .should("contain", "Test3");

--- a/cypress/integration/visitorCanChangePage.feature.js
+++ b/cypress/integration/visitorCanChangePage.feature.js
@@ -1,13 +1,18 @@
-describe("Visitor can change page and get more articles", () => {
-  it("successfully", () => {
+describe("Visitor can change page and another set of articles", () => {
+  it("successfully goes to next page", () => {
     cy.route({
       method: "GET",
-      url: "http://localhost:3000/api/v1/articles**",
+      url: "http://localhost:3000/api/v1/articles*page=1",
       response: "fixture:side_articles_shown.json"
+    });
+    cy.route({
+      method: "GET",
+      url: "http://localhost:3000/api/v1/articles*page=2",
+      response: "fixture:side_articles_shown_page2.json"
     });
     cy.visit("/");
     cy.get("#next-button").click()
-    cy.get("#side-articles-1")
+    cy.get("#side-article-6")
       .should("contain", "Test6");
   });
 });

--- a/cypress/integration/visitorCanChangePage.feature.js
+++ b/cypress/integration/visitorCanChangePage.feature.js
@@ -15,4 +15,22 @@ describe("Visitor can change page and another set of articles", () => {
     cy.get("#side-article-6")
       .should("contain", "Test6");
   });
+
+  it("successfully goes to previous page", () => {
+    cy.route({
+      method: "GET",
+      url: "http://localhost:3000/api/v1/articles*page=2",
+      response: "fixture:side_articles_shown.json"
+    });
+    cy.route({
+      method: "GET",
+      url: "http://localhost:3000/api/v1/articles*page=2",
+      response: "fixture:side_articles_shown_page2.json"
+    });
+    cy.visit("/");
+    cy.get("#next-button").click()
+    cy.get("#prev-button").click()
+    cy.get("#side-article-3")
+      .should("contain", "Test3");
+  });
 });

--- a/src/components/DisplaySideArticles.jsx
+++ b/src/components/DisplaySideArticles.jsx
@@ -85,19 +85,21 @@ const DisplaySideArticles = props => {
       </div>
       <div>
         {(props.sideArticles && props.sideArticles.meta.prev_page != null) ? (
-          <Button
+          <Button basic color="black"
           id="prev-button"
           onClick={() => pageButtonHandler(props.currentPage - 1)}
         >
+          <i aria-hidden="true" class="left chevron icon"></i>
           {t("dsa.prevPageButton")}
         </Button>
         ) : null}
         {(props.sideArticles && props.sideArticles.meta.next_page != null) ? (
-        <Button
+        <Button basic color="black"
           id="next-button"
           onClick={() => pageButtonHandler(props.currentPage + 1)}
         >
           {t("dsa.nextPageButton")}
+          <i aria-hidden="true" class="right chevron icon"></i>
         </Button>
         ) : null }
       </div>

--- a/src/components/DisplaySideArticles.jsx
+++ b/src/components/DisplaySideArticles.jsx
@@ -32,7 +32,6 @@ const DisplaySideArticles = props => {
   }, [props.currentPage]);
 
   useEffect(() => {
-    debugger
     if (props.sideArticles && props.sideArticles.articles.length > 0) {
       props.changeCurrentArticleId(props.sideArticles.articles[0].id);
     } else if (props.sideArticles && props.sideArticles.articles.length == 0 && props.category ) {
@@ -85,18 +84,22 @@ const DisplaySideArticles = props => {
         )}
       </div>
       <div>
-        <Button
+        {(props.sideArticles && props.sideArticles.meta.prev_page != null) ? (
+          <Button
           id="prev-button"
           onClick={() => pageButtonHandler(props.currentPage - 1)}
         >
           {t("dsa.prevPageButton")}
         </Button>
+        ) : null}
+        {(props.sideArticles && props.sideArticles.meta.next_page != null) ? (
         <Button
           id="next-button"
           onClick={() => pageButtonHandler(props.currentPage + 1)}
         >
           {t("dsa.nextPageButton")}
         </Button>
+        ) : null }
       </div>
     </>
   );

--- a/src/components/DisplaySideArticles.jsx
+++ b/src/components/DisplaySideArticles.jsx
@@ -2,7 +2,7 @@ import React, { useEffect } from "react";
 import { connect } from "react-redux";
 import { getArticles } from "../modules/article";
 import { useTranslation } from "react-i18next";
-import { Button } from "semantic-ui-react"
+import { Button } from "semantic-ui-react";
 
 const DisplaySideArticles = props => {
   const { t } = useTranslation();
@@ -38,8 +38,8 @@ const DisplaySideArticles = props => {
   }, [props.language]);
 
   const pageButtonHandler = newPageNumber => {
-    props.changeCurrentPage(newPageNumber)
-  }
+    props.changeCurrentPage(newPageNumber);
+  };
 
   let articlesList;
 
@@ -70,8 +70,18 @@ const DisplaySideArticles = props => {
       ) : (
         <p id="error-message">{t("dsa.error")}</p>
       )}
-      <Button id="prev-button" onClick={() => pageButtonHandler(props.currentPage - 1)}>Previous page</Button>
-      <Button id="next-button" onClick={() => pageButtonHandler(props.currentPage + 1)}>Next page</Button>
+      <Button
+        id="prev-button"
+        onClick={() => pageButtonHandler(props.currentPage - 1)}
+      >
+        Previous page
+      </Button>
+      <Button
+        id="next-button"
+        onClick={() => pageButtonHandler(props.currentPage + 1)}
+      >
+        Next page
+      </Button>
     </div>
   );
 };
@@ -92,7 +102,6 @@ const mapDispatchToProps = dispatch => {
       dispatch({ type: "CHANGE_ARTICLES_DATA", payload: articlesData });
     },
     changeCurrentPage: currentPage => {
-      debugger
       dispatch({ type: "CHANGE_CURRENT_PAGE", payload: currentPage });
     },
     changeCurrentArticleId: id => {

--- a/src/components/DisplaySideArticles.jsx
+++ b/src/components/DisplaySideArticles.jsx
@@ -8,7 +8,11 @@ const DisplaySideArticles = props => {
   const { t } = useTranslation();
 
   const getArticleShowData = async () => {
-    const articlesData = await getArticles(props.language, props.currentPage, props.category);
+    const articlesData = await getArticles(
+      props.language,
+      props.currentPage,
+      props.category
+    );
     props.changeSideArticlesData(articlesData);
     props.changeCurrentPage(articlesData.meta.current_page);
   };
@@ -28,8 +32,16 @@ const DisplaySideArticles = props => {
   }, [props.currentPage]);
 
   useEffect(() => {
+    debugger
     if (props.sideArticles && props.sideArticles.articles.length > 0) {
       props.changeCurrentArticleId(props.sideArticles.articles[0].id);
+    } else if (props.sideArticles && props.sideArticles.articles.length == 0 && props.category ) {
+      props.changeSideMessage(`${t("dsa.categoryEmpty")}`);
+      props.changeMessage(`${t("dsa.categoryEmpty")}`);
+      props.changeCurrentArticle("");
+    } else if (props.sideArticles && props.sideArticles.articles.length == 0) {
+      props.changeSideMessage(`${t("dsa.error")}`);
+      props.changeCurrentArticleId("");
     }
   }, [props.sideArticles]);
 
@@ -62,27 +74,31 @@ const DisplaySideArticles = props => {
   }
 
   return (
-    <div id="side-articles">
-      {!props.sideArticles ? (
-        <p id="message">{t("dsa.loading")}</p>
-      ) : props.sideArticles.articles.length > 0 ? (
-        articlesList
-      ) : (
-        <p id="error-message">{t("dsa.error")}</p>
-      )}
-      <Button
-        id="prev-button"
-        onClick={() => pageButtonHandler(props.currentPage - 1)}
-      >
-        Previous page
-      </Button>
-      <Button
-        id="next-button"
-        onClick={() => pageButtonHandler(props.currentPage + 1)}
-      >
-        Next page
-      </Button>
-    </div>
+    <>
+      <div id="side-articles">
+        {!props.sideArticles ? (
+          <p id="message">{t("dsa.loading")}</p>
+        ) : props.sideArticles.articles.length > 0 ? (
+          articlesList
+        ) : (
+          <p id="error-message">{props.sideMessage}</p>
+        )}
+      </div>
+      <div>
+        <Button
+          id="prev-button"
+          onClick={() => pageButtonHandler(props.currentPage - 1)}
+        >
+          {t("dsa.prevPageButton")}
+        </Button>
+        <Button
+          id="next-button"
+          onClick={() => pageButtonHandler(props.currentPage + 1)}
+        >
+          {t("dsa.nextPageButton")}
+        </Button>
+      </div>
+    </>
   );
 };
 
@@ -93,7 +109,7 @@ const mapStateToProps = state => {
     currentPage: state.currentPage,
     language: state.language,
     category: state.category,
-    message: state.message
+    sideMessage: state.sideMessage
   };
 };
 
@@ -107,6 +123,15 @@ const mapDispatchToProps = dispatch => {
     },
     changeCurrentArticleId: id => {
       dispatch({ type: "CHANGE_ARTICLE_ID", payload: id });
+    },
+    changeSideMessage: message => {
+      dispatch({ type: "CHANGE_SIDEMESSAGE", payload: message });
+    },
+    changeMessage: message => {
+      dispatch({ type: "CHANGE_SIDEMESSAGE", payload: message });
+    },
+    changeCurrentArticle: article => {
+      dispatch({ type: "CHANGE_ARTICLE", payload: article });
     }
   };
 };

--- a/src/components/DisplaySideArticles.jsx
+++ b/src/components/DisplaySideArticles.jsx
@@ -37,8 +37,8 @@ const DisplaySideArticles = props => {
     getArticleShowData();
   }, [props.language]);
 
-  const nextPageHandler = () => {
-    props.changeCurrentPage(props.currentPage + 1)
+  const pageButtonHandler = newPageNumber => {
+    props.changeCurrentPage(newPageNumber)
   }
 
   let articlesList;
@@ -70,8 +70,8 @@ const DisplaySideArticles = props => {
       ) : (
         <p id="error-message">{t("dsa.error")}</p>
       )}
-      <Button>Previous page</Button>
-      <Button id="next-button" onClick={nextPageHandler}>Next page</Button>
+      <Button id="prev-button" onClick={() => pageButtonHandler(props.currentPage - 1)}>Previous page</Button>
+      <Button id="next-button" onClick={() => pageButtonHandler(props.currentPage + 1)}>Next page</Button>
     </div>
   );
 };

--- a/src/components/DisplaySideArticles.jsx
+++ b/src/components/DisplaySideArticles.jsx
@@ -2,12 +2,13 @@ import React, { useEffect } from "react";
 import { connect } from "react-redux";
 import { getArticles } from "../modules/article";
 import { useTranslation } from "react-i18next";
+import { Button } from "semantic-ui-react"
 
 const DisplaySideArticles = props => {
   const { t } = useTranslation();
 
   const getArticleShowData = async () => {
-    const articlesData = await getArticles(props.language);
+    const articlesData = await getArticles(props.language, props.currentPage);
     props.changeSideArticlesData(articlesData);
     props.changeCurrentPage(articlesData.meta.current_page);
   };
@@ -20,14 +21,25 @@ const DisplaySideArticles = props => {
   }
 
   useEffect(() => {
+    getArticleShowData();
     if (props.sideArticles && props.sideArticles.articles.length > 0) {
       props.changeCurrentArticleId(props.sideArticles.articles[0].id);
     }
   }, [props.currentPage]);
 
   useEffect(() => {
+    if (props.sideArticles && props.sideArticles.articles.length > 0) {
+      props.changeCurrentArticleId(props.sideArticles.articles[0].id);
+    }
+  }, [props.sideArticles]);
+
+  useEffect(() => {
     getArticleShowData();
   }, [props.language]);
+
+  const nextPageHandler = () => {
+    props.changeCurrentPage(props.currentPage + 1)
+  }
 
   let articlesList;
 
@@ -58,6 +70,8 @@ const DisplaySideArticles = props => {
       ) : (
         <p id="error-message">{t("dsa.error")}</p>
       )}
+      <Button>Previous page</Button>
+      <Button id="next-button" onClick={nextPageHandler}>Next page</Button>
     </div>
   );
 };
@@ -78,6 +92,7 @@ const mapDispatchToProps = dispatch => {
       dispatch({ type: "CHANGE_ARTICLES_DATA", payload: articlesData });
     },
     changeCurrentPage: currentPage => {
+      debugger
       dispatch({ type: "CHANGE_CURRENT_PAGE", payload: currentPage });
     },
     changeCurrentArticleId: id => {

--- a/src/components/DisplaySideArticles.jsx
+++ b/src/components/DisplaySideArticles.jsx
@@ -8,7 +8,7 @@ const DisplaySideArticles = props => {
   const { t } = useTranslation();
 
   const getArticleShowData = async () => {
-    const articlesData = await getArticles(props.language, props.currentPage);
+    const articlesData = await getArticles(props.language, props.currentPage, props.category);
     props.changeSideArticlesData(articlesData);
     props.changeCurrentPage(articlesData.meta.current_page);
   };
@@ -35,7 +35,7 @@ const DisplaySideArticles = props => {
 
   useEffect(() => {
     getArticleShowData();
-  }, [props.language]);
+  }, [props.language, props.category]);
 
   const pageButtonHandler = newPageNumber => {
     props.changeCurrentPage(newPageNumber);
@@ -92,6 +92,7 @@ const mapStateToProps = state => {
     currentArticleId: state.currentArticleId,
     currentPage: state.currentPage,
     language: state.language,
+    category: state.category,
     message: state.message
   };
 };

--- a/src/components/Navbar.jsx
+++ b/src/components/Navbar.jsx
@@ -38,9 +38,9 @@ const Navbar = props => {
   const changeCategory = async event => {
     let articlesData;
     if (event) {
-      articlesData = await getArticles(props.language, event);
+      articlesData = await getArticles(props.language, props.currentPage, event);
     } else {
-      articlesData = await getArticles(props.language);
+      articlesData = await getArticles(props.language, props.currentPage);
     }
     if (articlesData.articles.length > 0) {
       props.changeSideArticlesData(articlesData);
@@ -83,7 +83,8 @@ const Navbar = props => {
 const mapStateToProps = state => {
   return {
     currentArticleId: state.currentArticleId,
-    language: state.language
+    language: state.language,
+    currentPage: state.currentPage
   };
 };
 

--- a/src/components/Navbar.jsx
+++ b/src/components/Navbar.jsx
@@ -2,7 +2,6 @@ import React, { useEffect } from "react";
 import { Menu } from "semantic-ui-react";
 import { useTranslation } from 'react-i18next';
 import { connect } from "react-redux";
-import { getArticles, getCurrentArticle } from "../modules/article";
 
 const Navbar = props => {
   const { t, i18n } = useTranslation("common");
@@ -27,35 +26,11 @@ const Navbar = props => {
     }
   }, []);
 
-  const toggleCategory = async event => {
+  const toggleCategory = event => {
     if (event.target.id == "return") {
-      await changeCategory();
+      props.changeCategory(null)
     } else {
-      await changeCategory(event);
-    }
-  };
-
-  const changeCategory = async event => {
-    let articlesData;
-    if (event) {
-      articlesData = await getArticles(props.language, props.currentPage, event);
-    } else {
-      articlesData = await getArticles(props.language, props.currentPage);
-    }
-    if (articlesData.articles.length > 0) {
-      props.changeSideArticlesData(articlesData);
-      props.changeCurrentPage(articlesData.meta.current_page);
-      const article = await getCurrentArticle(articlesData.articles[0].id, props.language);
-      if (article.error) {
-        props.changeMessage(article.error);
-      } else {
-        props.changeCurrentArticle(article);
-      }
-    } else {
-      props.changeCurrentArticle("");
-      props.changeMessage("No articles in that category yet");
-      props.changeSideArticlesData("");
-      props.changeCurrentPage("")
+      props.changeCategory(event.target.id)
     }
   };
 
@@ -90,23 +65,8 @@ const mapStateToProps = state => {
 
 const mapDispatchToProps = dispatch => {
   return {
-    changeSideArticlesData: articlesData => {
-      dispatch({ type: "CHANGE_ARTICLES_DATA", payload: articlesData });
-    },
-    changeCurrentPage: currentPage => {
-      dispatch({ type: "CHANGE_CURRENT_PAGE", payload: currentPage });
-    },
-    changeCurrentArticleId: id => {
-      dispatch({ type: "CHANGE_ARTICLE_ID", payload: id });
-    },
-    changeCurrentArticle: article => {
-      dispatch({ type: "CHANGE_ARTICLE", payload: article });
-    },
-      changeMessage: message => {
-      dispatch({ type: "CHANGE_MESSAGE", payload: message });
-    },
-    changeSideArticlesData: articlesData => {
-      dispatch({ type: "CHANGE_ARTICLES_DATA", payload: articlesData });
+    changeCategory: category => {
+      dispatch({ type: "CHANGE_CATEGORY", payload: category });
     },
     changeLanguage: language => {
       dispatch({ type: "CHANGE_LANGUAGE", payload: language });

--- a/src/locales/default.json
+++ b/src/locales/default.json
@@ -10,7 +10,10 @@
     },
     "dsa": {
       "loading": "Loading...",
-      "error": "No articles found"
+      "error": "No articles found",
+      "categoryEmpty": "No articles in that category yet",
+      "nextPageButton": "Next page",
+      "prevPageButton": "Previous page"
     },
     "footer": {
       "info1": "CEO and Editor in chief:",

--- a/src/locales/default.json
+++ b/src/locales/default.json
@@ -12,8 +12,8 @@
       "loading": "Loading...",
       "error": "No articles found",
       "categoryEmpty": "No articles in that category yet",
-      "nextPageButton": "Next page",
-      "prevPageButton": "Previous page"
+      "nextPageButton": "Next",
+      "prevPageButton": "Previous"
     },
     "footer": {
       "info1": "CEO and Editor in chief:",

--- a/src/locales/default_sv.json
+++ b/src/locales/default_sv.json
@@ -12,8 +12,8 @@
       "Loading": "Laddar...",
       "error": "Inga artiklar",
       "categoryEmpty": "Inga artiklar i denna kategori ännu",
-      "nextPageButton": "Nästa sida",
-      "prevPageButton": "Föregående sida"
+      "nextPageButton": "Nästa",
+      "prevPageButton": "Föregående"
     },
     "footer": {
       "info1": "VD och chefredaktör:",

--- a/src/locales/default_sv.json
+++ b/src/locales/default_sv.json
@@ -10,7 +10,10 @@
     },
     "dsa": {
       "Loading": "Laddar...",
-      "error": "Inga artiklar"
+      "error": "Inga artiklar",
+      "categoryEmpty": "Inga artiklar i denna kategori ännu",
+      "nextPageButton": "Nästa sida",
+      "prevPageButton": "Föregående sida"
     },
     "footer": {
       "info1": "VD och chefredaktör:",

--- a/src/modules/article.js
+++ b/src/modules/article.js
@@ -18,22 +18,13 @@ const getCurrentArticle = async (id, language) => {
   }
 };
 
-const getArticles = async (language, page, event) => {
-  if (event) {
-    const response = await axios({
-      url: "/articles",
-      method: "GET",
-      params: { category: event.target.id, locale: language, page: page }
-    });
-    return response.data;
-  } else {
-    const response = await axios({
-      url: "/articles",
-      method: "GET",
-      params: { locale: language, page: page }
-    });
-    return response.data;
-  }
+const getArticles = async (language, page, category) => {
+  const response = await axios({
+    url: "/articles",
+    method: "GET",
+    params: { locale: language, page: page, category: category }
+  });
+  return response.data;
 };
 
 const createArticle = async (title_en, title_sv, body_en, body_sv, category, image) => {

--- a/src/modules/article.js
+++ b/src/modules/article.js
@@ -18,19 +18,19 @@ const getCurrentArticle = async (id, language) => {
   }
 };
 
-const getArticles = async (language, event) => {
+const getArticles = async (language, page, event) => {
   if (event) {
     const response = await axios({
       url: "/articles",
       method: "GET",
-      params: { category: event.target.id, locale: language }
+      params: { category: event.target.id, locale: language, page: page }
     });
     return response.data;
   } else {
     const response = await axios({
       url: "/articles",
       method: "GET",
-      params: { locale: language }
+      params: { locale: language, page: page }
     });
     return response.data;
   }

--- a/src/state/reducers/rootReducer.js
+++ b/src/state/reducers/rootReducer.js
@@ -67,6 +67,11 @@ const rootReducer = (state = initialState, action) => {
         ...state,
         language: action.payload
       };
+    case "CHANGE_CATEGORY":
+    return {
+      ...state,
+      category: action.payload
+    };
     default:
       return {
         ...state

--- a/src/state/reducers/rootReducer.js
+++ b/src/state/reducers/rootReducer.js
@@ -12,6 +12,11 @@ const rootReducer = (state = initialState, action) => {
         ...state,
         message: action.payload
       };
+    case "CHANGE_SIDEMESSAGE":
+      return {
+        ...state,
+        sideMessage: action.payload
+      };
     case "CHANGE_ARTICLES_DATA":
       return {
         ...state,

--- a/src/state/reducers/rootReducer.js
+++ b/src/state/reducers/rootReducer.js
@@ -73,10 +73,10 @@ const rootReducer = (state = initialState, action) => {
         language: action.payload
       };
     case "CHANGE_CATEGORY":
-    return {
-      ...state,
-      category: action.payload
-    };
+      return {
+        ...state,
+        category: action.payload
+      };
     default:
       return {
         ...state

--- a/src/state/store/initialState.js
+++ b/src/state/store/initialState.js
@@ -4,6 +4,7 @@ const initialState = {
   sideArticles: null,
   currentPage: null,
   message: "Loading...",
+  sideMessage: "Loading...",
   authenticated: false,
   authMessage: null,
   displayLoginButton: true,

--- a/src/state/store/initialState.js
+++ b/src/state/store/initialState.js
@@ -12,5 +12,6 @@ const initialState = {
   userShowData: null,
   paymentMessage: null,
   language: "en",
+  category: null,
 }
 export default initialState


### PR DESCRIPTION
[PT - Visitor can change page](https://www.pivotaltracker.com/story/show/171022680)

Adds buttons for going to previous and next page of articles
Buttons sets `currentPage` to `currentPage + 1` (next) or `currentPage - 1 `(previous)
Moves logic for switching category from Navbar component to DisplaySideArticles
![Screenshot 2020-01-31 at 16 32 28](https://user-images.githubusercontent.com/56539700/73551773-50f7b800-4447-11ea-82fd-f075951e5cde.png)
